### PR TITLE
Enable S3 website hosting and lambda output

### DIFF
--- a/infrastructure/live/dev/lambda/terragrunt.hcl
+++ b/infrastructure/live/dev/lambda/terragrunt.hcl
@@ -6,6 +6,10 @@ dependency "iam" {
   config_path = "../iam"
 }
 
+dependency "output_bucket" {
+  config_path = "../s3_output"
+}
+
 terraform {
   source = "../../../modules/lambda"
 }
@@ -14,4 +18,5 @@ inputs = {
   function_name   = "laas-dev-handler"
   lambda_role_arn = dependency.iam.outputs.lambda_role_arn
   timeout         = 60
+  output_bucket_name = dependency.output_bucket.outputs.bucket_name
 }

--- a/infrastructure/live/prod/lambda/terragrunt.hcl
+++ b/infrastructure/live/prod/lambda/terragrunt.hcl
@@ -6,6 +6,10 @@ dependency "iam" {
   config_path = "../iam"
 }
 
+dependency "output_bucket" {
+  config_path = "../s3_output"
+}
+
 terraform {
   source = "../../../modules/lambda"
 }
@@ -14,4 +18,5 @@ inputs = {
   function_name   = "laas-prod-handler"
   lambda_role_arn = dependency.iam.outputs.lambda_role_arn
   timeout         = 60
+  output_bucket_name = dependency.output_bucket.outputs.bucket_name
 }

--- a/infrastructure/modules/lambda/handler.py
+++ b/infrastructure/modules/lambda/handler.py
@@ -1,3 +1,19 @@
+import os
+import boto3
+
+s3 = boto3.client("s3")
+
+
 def handler(event, context):
     print("Event received:", event)
+
+    bucket = os.environ.get("OUTPUT_BUCKET")
+    if bucket:
+        s3.put_object(
+            Bucket=bucket,
+            Key="index.html",
+            Body="<html><body>Hello from Lambda</body></html>",
+            ContentType="text/html",
+        )
+
     return {"statusCode": 200, "body": "ok"}

--- a/infrastructure/modules/lambda/main.tf
+++ b/infrastructure/modules/lambda/main.tf
@@ -13,4 +13,13 @@ resource "aws_lambda_function" "this" {
   filename         = data.archive_file.lambda_zip.output_path
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   timeout          = var.timeout
+
+  dynamic "environment" {
+    for_each = var.output_bucket_name != "" ? [1] : []
+    content {
+      variables = {
+        OUTPUT_BUCKET = var.output_bucket_name
+      }
+    }
+  }
 }

--- a/infrastructure/modules/lambda/variables.tf
+++ b/infrastructure/modules/lambda/variables.tf
@@ -10,3 +10,8 @@ variable "timeout" {
   type    = number
   default = 60
 }
+
+variable "output_bucket_name" {
+  type    = string
+  default = ""
+}

--- a/infrastructure/modules/s3_bucket/main.tf
+++ b/infrastructure/modules/s3_bucket/main.tf
@@ -10,3 +10,13 @@ resource "aws_s3_bucket_public_access_block" "block" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Configure the bucket for static website hosting so that
+# CloudFront can serve the generated HTML pages.
+resource "aws_s3_bucket_website_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  index_document {
+    suffix = "index.html"
+  }
+}


### PR DESCRIPTION
## Summary
- configure S3 buckets for website hosting
- allow Lambda to know the output bucket
- write index.html file from Lambda
- pass output bucket name from dev/prod configurations

## Testing
- `terraform fmt -recursive -check infrastructure/modules` *(fails: command not found)*
- `terragrunt -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473d5e2f1c83318cc35587f249eb5d