### PR TITLE
Implement lambda to call Bedrock

### DIFF
--- a/infrastructure/live/dev/lambda/terragrunt.hcl
+++ b/infrastructure/live/dev/lambda/terragrunt.hcl
@@ -6,6 +6,18 @@ dependency "iam" {
   config_path = "../iam"
 }
 
+dependency "input_bucket" {
+  config_path = "../s3_input"
+}
+
+dependency "output_bucket" {
+  config_path = "../s3_output"
+}
+
+dependency "cloudfront" {
+  config_path = "../cloudfront"
+}
+
 terraform {
   source = "../../../modules/lambda"
 }
@@ -14,4 +26,9 @@ inputs = {
   function_name   = "laas-dev-handler"
   lambda_role_arn = dependency.iam.outputs.lambda_role_arn
   timeout         = 60
+  input_bucket_name  = dependency.input_bucket.outputs.bucket_name
+  input_key          = "index.html"
+  output_bucket_name = dependency.output_bucket.outputs.bucket_name
+  bedrock_model_id   = "anthropic.claude-v2"
+  cloudfront_domain  = dependency.cloudfront.outputs.distribution_domain_name
 }

--- a/infrastructure/live/prod/lambda/terragrunt.hcl
+++ b/infrastructure/live/prod/lambda/terragrunt.hcl
@@ -6,6 +6,18 @@ dependency "iam" {
   config_path = "../iam"
 }
 
+dependency "input_bucket" {
+  config_path = "../s3_input"
+}
+
+dependency "output_bucket" {
+  config_path = "../s3_output"
+}
+
+dependency "cloudfront" {
+  config_path = "../cloudfront"
+}
+
 terraform {
   source = "../../../modules/lambda"
 }
@@ -14,4 +26,9 @@ inputs = {
   function_name   = "laas-prod-handler"
   lambda_role_arn = dependency.iam.outputs.lambda_role_arn
   timeout         = 60
+  input_bucket_name  = dependency.input_bucket.outputs.bucket_name
+  input_key          = "index.html"
+  output_bucket_name = dependency.output_bucket.outputs.bucket_name
+  bedrock_model_id   = "anthropic.claude-v2"
+  cloudfront_domain  = dependency.cloudfront.outputs.distribution_domain_name
 }

--- a/infrastructure/modules/lambda/handler.py
+++ b/infrastructure/modules/lambda/handler.py
@@ -1,3 +1,52 @@
+"""Lambda handler that generates landing pages using AWS Bedrock."""
+
+import json
+import os
+import uuid
+
+import boto3
+
+
+s3_client = boto3.client("s3")
+bedrock_runtime = boto3.client("bedrock-runtime")
+
+
 def handler(event, context):
+    """Generate a landing page from a template stored in S3."""
     print("Event received:", event)
-    return {"statusCode": 200, "body": "ok"}
+
+    input_bucket = os.environ["INPUT_BUCKET"]
+    input_key = os.environ["INPUT_KEY"]
+    output_bucket = os.environ["OUTPUT_BUCKET"]
+    bedrock_model = os.environ["BEDROCK_MODEL_ID"]
+    cloudfront_domain = os.environ.get("CLOUDFRONT_DOMAIN")
+
+    template_obj = s3_client.get_object(Bucket=input_bucket, Key=input_key)
+    template_html = template_obj["Body"].read().decode("utf-8")
+
+    prompt = f"Modify the following HTML to create a landing page:\n{template_html}"
+
+    response = bedrock_runtime.invoke_model(
+        modelId=bedrock_model,
+        contentType="application/json",
+        accept="application/json",
+        body=json.dumps({"inputText": prompt}).encode("utf-8"),
+    )
+
+    result = json.loads(response["body"].read())
+    generated_html = result.get("results", [{}])[0].get("outputText", "")
+
+    output_key = f"{uuid.uuid4()}.html"
+    s3_client.put_object(
+        Bucket=output_bucket,
+        Key=output_key,
+        Body=generated_html,
+        ContentType="text/html",
+    )
+
+    if cloudfront_domain:
+        url = f"https://{cloudfront_domain}/{output_key}"
+    else:
+        url = f"https://{output_bucket}.s3.amazonaws.com/{output_key}"
+
+    return {"statusCode": 200, "body": json.dumps({"url": url})}

--- a/infrastructure/modules/lambda/main.tf
+++ b/infrastructure/modules/lambda/main.tf
@@ -13,4 +13,14 @@ resource "aws_lambda_function" "this" {
   filename         = data.archive_file.lambda_zip.output_path
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   timeout          = var.timeout
+
+  environment {
+    variables = {
+      INPUT_BUCKET       = var.input_bucket_name
+      INPUT_KEY          = var.input_key
+      OUTPUT_BUCKET      = var.output_bucket_name
+      BEDROCK_MODEL_ID   = var.bedrock_model_id
+      CLOUDFRONT_DOMAIN  = var.cloudfront_domain
+    }
+  }
 }

--- a/infrastructure/modules/lambda/variables.tf
+++ b/infrastructure/modules/lambda/variables.tf
@@ -10,3 +10,24 @@ variable "timeout" {
   type    = number
   default = 60
 }
+
+variable "input_bucket_name" {
+  type = string
+}
+
+variable "input_key" {
+  type = string
+}
+
+variable "output_bucket_name" {
+  type = string
+}
+
+variable "bedrock_model_id" {
+  type = string
+}
+
+variable "cloudfront_domain" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
## Summary
- implement Lambda logic to generate HTML with AWS Bedrock
- inject required environment variables into Lambda module
- pass variables from Terragrunt for dev and prod environments

## Testing
- `python -m py_compile infrastructure/modules/lambda/handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68473d597948833186ca16ab2cd64fa3